### PR TITLE
Fixed typo in VITALID field label.

### DIFF
--- a/Oracle/PCORNetLoader_ora.sql
+++ b/Oracle/PCORNetLoader_ora.sql
@@ -243,7 +243,7 @@ END;
 /
 
 CREATE TABLE vital (
-	VITALIID varchar(19)  primary key,
+	VITALID varchar(19)  primary key,
 	PATID varchar(50) NULL,
 	ENCOUNTERID varchar(50) NULL,
 	MEASURE_DATE date NULL,


### PR DESCRIPTION
Whoops.